### PR TITLE
구글 / 애플 로그인 Network Service 연결

### DIFF
--- a/Trazzle/Trazzle/Network/NetworkService.swift
+++ b/Trazzle/Trazzle/Network/NetworkService.swift
@@ -36,6 +36,14 @@ class NetworkService {
         return request(.kakaoLogin(accessToken: accessToken), type: User.self)
     }
     
+    func googleLogin(accessToken: String) -> AnyPublisher<User, TZError> {
+        return request(.googleLogin(accessToken: accessToken), type: User.self)
+    }
+    
+    func appleLogin(accessToken: String) -> AnyPublisher<User, TZError> {
+        return request(.kakaoLogin(accessToken: accessToken), type: User.self)
+    }
+    
     func testLogin(account: String) -> AnyPublisher<User, TZError> {
         return request(.testLogin(account: account), type: User.self)
     }

--- a/Trazzle/Trazzle/Network/TrazzleAPI.swift
+++ b/Trazzle/Trazzle/Network/TrazzleAPI.swift
@@ -12,6 +12,8 @@ enum TrazzleAPI {
     // MARK: Login
     case testLogin(account: String)
     case kakaoLogin(accessToken: String)
+    case googleLogin(accessToken: String)
+    case appleLogin(accessToken: String)
     case editProfile(name: String, intro: String, profileImageFile: String)
 }
 
@@ -25,6 +27,8 @@ extension TrazzleAPI: TargetType {
         // MARK: Login
         case .testLogin: return "users/sign-in/account"
         case .kakaoLogin: return "users/sign-in/kakao"
+        case .googleLogin: return "users/sign-in/google"
+        case .appleLogin: return "users/sign-in/apple"
         // MARK: Profile
         case .editProfile: return "users/profile"
         }
@@ -47,6 +51,16 @@ extension TrazzleAPI: TargetType {
         case let .kakaoLogin(accessToken):
             params["accessToken"] = accessToken
             params["oauthProvider"] = LoginProviderType.kakao.typeName()
+            return .requestParameters(parameters: params, encoding: URLEncoding.default)
+            
+        case let .googleLogin(accessToken):
+            params["accessToken"] = accessToken
+            params["oauthProvider"] = LoginProviderType.google.typeName()
+            return .requestParameters(parameters: params, encoding: URLEncoding.default)
+            
+        case let .appleLogin(accessToken):
+            params["accessToken"] = accessToken
+            params["oauthProvider"] = LoginProviderType.apple.typeName()
             return .requestParameters(parameters: params, encoding: URLEncoding.default)
             
         // MARK: Profile

--- a/Trazzle/Trazzle/View/HomeView/HomeView.swift
+++ b/Trazzle/Trazzle/View/HomeView/HomeView.swift
@@ -69,7 +69,7 @@ struct HomeView: View {
                         },
                         content: {
                             if LoginManager.shared.isLoggedIn {
-                                
+                                CountryListView()
                             }
                             else {
                                 LoginView(isFullScreenOver: $isFullSceenOver)

--- a/Trazzle/Trazzle/View/LoginView/AppleButton.swift
+++ b/Trazzle/Trazzle/View/LoginView/AppleButton.swift
@@ -9,9 +9,12 @@ import AuthenticationServices
 import SwiftUI
 
 struct AppleButton: View {
-    let loginSender = LoginSender()
     let authorize = Authorize()
-    let appleUrl = "https://trazzle.p-e.kr/api/users/sign-in/apple"
+    let vm: LoginViewModel
+    
+    init(vm: LoginViewModel) {
+        self.vm = vm
+    }
     
     var body: some View {
         Button(action: {
@@ -40,7 +43,8 @@ struct AppleButton: View {
                     authorize.completionHandler = { tokenString in
                         // completionHandler를 통해 전달받은 데이터 처리
                         if let token = tokenString {
-                            loginSender.sendData(url: appleUrl, accessToken: token, oauthProvider: "a")
+                            print(token)
+                            vm.doAppleLogin(accessToken: token)
                         } else {
                             print("애플 token nil")
                         }

--- a/Trazzle/Trazzle/View/LoginView/GoogleButton.swift
+++ b/Trazzle/Trazzle/View/LoginView/GoogleButton.swift
@@ -13,8 +13,11 @@ struct GoogleButton: View {
     
     // GoogleSignInButtonViewModel 인스턴스 생성
     let viewModel = GoogleSignInButtonViewModel()
-    let loginSender = LoginSender()
-    let googleUrl = "https://trazzle.p-e.kr/api/users/sign-in/google"
+    let vm: LoginViewModel
+    
+    init(vm: LoginViewModel) {
+        self.vm = vm
+    }
     
     var body: some View {
         Button(action: {
@@ -68,7 +71,7 @@ struct GoogleButton: View {
                 
                 // 액세스 토큰
                 print("Access token: \(user.accessToken.tokenString)")
-                loginSender.sendData(url: googleUrl, accessToken: user.accessToken.tokenString, oauthProvider: "g")
+                vm.doGoogleLogin(accessToken: user.accessToken.tokenString)
                 
                 // 토큰을 사용하여 서버에 요청을 보낼 수 있습니다.
             } else {

--- a/Trazzle/Trazzle/View/LoginView/KakaoButton.swift
+++ b/Trazzle/Trazzle/View/LoginView/KakaoButton.swift
@@ -12,7 +12,6 @@ import KakaoSDKAuth
 import KakaoSDKUser
 
 struct KakaoButton: View{
-    let kakaoUrl = "https://trazzle.p-e.kr/api/users/sign-in/kakao"
     let vm: LoginViewModel
     
     init(vm: LoginViewModel) {
@@ -20,7 +19,6 @@ struct KakaoButton: View{
     }
 
     var body: some View{
-//        let loginSender = LoginSender()
         
         Button {
             if (UserApi.isKakaoTalkLoginAvailable()) {
@@ -33,7 +31,6 @@ struct KakaoButton: View{
                         // 소셜 로그인(회원가입 API CALL)
                         let token = oauthToken.accessToken
                         print(token)
-//                        loginSender.sendData(url: kakaoUrl, accessToken: token, oauthProvider: "k")
                         vm.doKakaoLogin(accessToken: token)
                     }
                 }
@@ -47,7 +44,6 @@ struct KakaoButton: View{
                         print("kakao success")
                         let token = oauthToken.accessToken
                         // 소셜 로그인(회원가입 API CALL)
-//                        loginSender.sendData(url: kakaoUrl, accessToken: token, oauthProvider: "k")
                         print(token)
                         vm.doKakaoLogin(accessToken: token)
                         

--- a/Trazzle/Trazzle/View/LoginView/LoginView.swift
+++ b/Trazzle/Trazzle/View/LoginView/LoginView.swift
@@ -47,8 +47,8 @@ struct LoginView: View {
             VStack {
                 Spacer()
                 KakaoButton(vm: vm)
-                GoogleButton()
-                AppleButton()
+                GoogleButton(vm: vm)
+                AppleButton(vm: vm)
                 
                 Text("로그인 및 회원가입시, 아래 내용에 동의하는 것으로 간주됩니다.")
                     .foregroundColor(.g400)

--- a/Trazzle/Trazzle/View/LoginView/LoginViewModel.swift
+++ b/Trazzle/Trazzle/View/LoginView/LoginViewModel.swift
@@ -29,6 +29,40 @@ class LoginViewModel: ObservableObject {
             })
             .store(in: &cancellable)
     }
+    
+    // 구글 로그인
+    func doGoogleLogin(accessToken: String) {
+        NetworkService.shared.googleLogin(accessToken: accessToken)
+            .sink(receiveCompletion: { error in
+                TZLoadingView.shared.hide()
+                print(error)
+            }, receiveValue: { data in
+                TZLoadingView.shared.hide()
+                // 🧩 로그인 성공
+                self.isLogined = true
+                
+                LoginManager.shared.user = data
+                print("login success: \(data)")
+            })
+            .store(in: &cancellable)
+    }
+    
+    // 애플 로그인
+    func doAppleLogin(accessToken: String) {
+        NetworkService.shared.appleLogin(accessToken: accessToken)
+            .sink(receiveCompletion: { error in
+                TZLoadingView.shared.hide()
+                print(error)
+            }, receiveValue: { data in
+                TZLoadingView.shared.hide()
+                // 🧩 로그인 성공
+                self.isLogined = true
+                
+                LoginManager.shared.user = data
+                print("login success: \(data)")
+            })
+            .store(in: &cancellable)
+    }
 
     // 테스트 로그인
     func dotestLogin(account: String) {


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

Network Service 구현에 따른 로그인 연동방식 수정

## 🧐 기능 구현 내용(Optional)

---

1. 구글 로그인 / 애플 로그인 Trazzle API 활용하도록 수정
2. 로그인이 된 상태에서 홈화면-플로팅버튼 클릭 - CountryListView로 이동

